### PR TITLE
fix(CALL_API): Use string constant instead of Symbols

### DIFF
--- a/lib/CALL_API.js
+++ b/lib/CALL_API.js
@@ -1,16 +1,14 @@
 /**
- * Symbol key that carries API call info interpreted by this Redux middleware.
+ * String key that carries API call info interpreted by this Redux middleware.
  *
- * @constant {symbol}
+ * @constant {string}
  * @access public
  * @default
  */
 'use strict';
 
-var _Symbol = require('babel-runtime/core-js/symbol')['default'];
-
 exports.__esModule = true;
-var CALL_API = _Symbol('Call API');
+var CALL_API = '@@redux-api-middleware/CALL_API';
 
 exports['default'] = CALL_API;
 module.exports = exports['default'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
  * @module redux-api-middleware
  * @requires isomorphic-fetch
  * @requires lodash.isplainobject
- * @exports {symbol} CALL_API
+ * @exports {string} CALL_API
  * @exports {function} isRSAA
  * @exports {function} validateRSAA
  * @exports {function} isValidRSAA

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -73,7 +73,7 @@ function validateRSAA(action) {
   }
 
   for (var key in action) {
-    if (key !== [_CALL_API2['default']]) {
+    if (key !== _CALL_API2['default']) {
       validationErrors.push('Invalid root key: ' + key);
     }
   }

--- a/src/CALL_API.js
+++ b/src/CALL_API.js
@@ -1,10 +1,10 @@
 /**
- * Symbol key that carries API call info interpreted by this Redux middleware.
+ * String key that carries API call info interpreted by this Redux middleware.
  *
- * @constant {symbol}
+ * @constant {string}
  * @access public
  * @default
  */
-const CALL_API = Symbol('Call API');
+const CALL_API = '@@redux-api-middleware/CALL_API';
 
 export default CALL_API;

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
  * @module redux-api-middleware
  * @requires isomorphic-fetch
  * @requires lodash.isplainobject
- * @exports {symbol} CALL_API
+ * @exports {string} CALL_API
  * @exports {function} isRSAA
  * @exports {function} validateRSAA
  * @exports {function} isValidRSAA

--- a/src/validation.js
+++ b/src/validation.js
@@ -86,7 +86,7 @@ function validateRSAA(action) {
   }
 
   for (let key in action) {
-    if (key !== [CALL_API]) {
+    if (key !== CALL_API) {
       validationErrors.push(`Invalid root key: ${key}`);
     }
   }


### PR DESCRIPTION
Android (and other like IE, iOS <9) do not support Symbols. The polyfills and transpiling the symbols with babel do no help, so use string instead of Symbol for better support.
